### PR TITLE
fix: standardize TypeScript imports to prevent TypeORM metadata errors

### DIFF
--- a/backend/src/entities/Attachment.ts
+++ b/backend/src/entities/Attachment.ts
@@ -1,6 +1,6 @@
 // src/entities/Attachment.ts
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm'
-import { Message } from './Message.js'
+import { Message } from './Message'
 
 @Entity({ name: 'attachments' })
 export class Attachment {

--- a/backend/src/entities/Message.ts
+++ b/backend/src/entities/Message.ts
@@ -1,7 +1,7 @@
 // src/entities/Message.ts
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, Index, OneToMany, JoinColumn } from 'typeorm'
-import { Ticket } from './Ticket.js'
-import { Attachment } from './Attachment.js'
+import { Ticket } from './Ticket'
+import { Attachment } from './Attachment'
 
 @Entity({ name: 'messages' })
 export class Message {

--- a/backend/src/entities/Role.ts
+++ b/backend/src/entities/Role.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm'
-import { User } from './User.js'
+import { User } from './User'
 
 @Entity({ name: 'roles' })
 export class Role {

--- a/backend/src/entities/Ticket.ts
+++ b/backend/src/entities/Ticket.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, Index } from 'typeorm'
-import { Message } from './Message.js'
+import { Message } from './Message'
 
 export type TicketStatus = 'open' | 'pending' | 'resolved' | 'closed'
 

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm'
-import { Role } from './Role.js'
+import { Role } from './Role'
 
 @Entity({ name: 'users' })
 export class User {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,10 +23,10 @@ import cookieParser from 'cookie-parser'
 import rateLimit from 'express-rate-limit'
 import http from 'http'
 import { Server as IOServer } from 'socket.io'
-import { createDataSource } from './database/data-source.js'
-import { registerRoutes } from './routes/index.js'
-import { initWS } from './ws.js'
-import { ensureDirs } from './utils/fs.js' 
+import { createDataSource } from './database/data-source'
+import { registerRoutes } from './routes'
+import { initWS } from './ws'
+import { ensureDirs } from './utils/fs'
 
 // Create DataSource after environment variables are loaded
 const AppDataSource = createDataSource()

--- a/backend/src/routes/attachments.ts
+++ b/backend/src/routes/attachments.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
-import { requireAuth } from '../middleware/auth.js'
-import { AppDataSource } from '../database/data-source.js'
-import { Attachment } from '../entities/Attachment.js'
+import { requireAuth } from '../middleware/auth'
+import { AppDataSource } from '../database/data-source'
+import { Attachment } from '../entities/Attachment'
 import path from 'path'
 
 const r = Router()

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,8 +1,8 @@
 import { Express } from 'express'
-import auth from './auth.js'
-import tickets from './tickets.js'
-import whatsapp from './whatsapp.js'
-import attachments from './attachments.js'
+import auth from './auth'
+import tickets from './tickets'
+import whatsapp from './whatsapp'
+import attachments from './attachments'
 
 export function registerRoutes (app: Express) {
   app.use('/api/auth', auth)

--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express'
-import { requireAuth, requireRole } from '../middleware/auth.js'
-import { AppDataSource } from '../database/data-source.js'
-import { Ticket } from '../entities/Ticket.js'
-import { TicketService } from '../services/TicketService.js'
-import { WhatsAppService } from '../services/WhatsAppService.js'
+import { requireAuth, requireRole } from '../middleware/auth'
+import { AppDataSource } from '../database/data-source'
+import { Ticket } from '../entities/Ticket'
+import { TicketService } from '../services/TicketService'
+import { WhatsAppService } from '../services/WhatsAppService'
 
 const r = Router()
 

--- a/backend/src/routes/whatsapp.ts
+++ b/backend/src/routes/whatsapp.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
-import { requireAuth, requireRole } from '../middleware/auth.js'
-import { WhatsAppService } from '../services/WhatsAppService.js'
+import { requireAuth, requireRole } from '../middleware/auth'
+import { WhatsAppService } from '../services/WhatsAppService'
 import { promises as fs } from 'fs'
 import path from 'path'
 

--- a/backend/src/seed/seed.ts
+++ b/backend/src/seed/seed.ts
@@ -1,9 +1,9 @@
 import 'reflect-metadata'
 import dotenv from 'dotenv'
 import bcrypt from 'bcryptjs'
-import { AppDataSource } from '../database/data-source.js'
-import { Role } from '../entities/Role.js'
-import { User } from '../entities/User.js'
+import { AppDataSource } from '../database/data-source'
+import { Role } from '../entities/Role'
+import { User } from '../entities/User'
 
 dotenv.config()
 


### PR DESCRIPTION
## Summary
- remove `.js` extensions from local TypeScript imports
- ensure services and routes share the same entity instances for TypeORM

## Testing
- `npm test` (fails: Error: no test specified)
- `(backend) npm test` (fails: Missing script: "test")
- `(backend) npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aebfd82560833298bd0e39259c402d