### PR TITLE
fix: standardize TypeScript imports and align frontend auth

### DIFF
--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -11,8 +11,10 @@ import { dirname } from 'path'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+export let AppDataSource: DataSource
+
 export function createDataSource() {
-  return new DataSource({
+  AppDataSource = new DataSource({
     type: 'mysql',
     host: process.env.DB_HOST,
     port: Number(process.env.DB_PORT || 3306),
@@ -24,6 +26,5 @@ export function createDataSource() {
     entities: [User, Role, Ticket, Message, WhatsAppSession, Attachment],
     migrations: [__dirname + '/../migrations/*.js']
   })
+  return AppDataSource
 }
-
-export const AppDataSource = createDataSource()

--- a/backend/src/entities/Attachment.ts
+++ b/backend/src/entities/Attachment.ts
@@ -1,6 +1,6 @@
 // src/entities/Attachment.ts
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm'
-import { Message } from './Message.js'
+import { Message } from './Message'
 
 @Entity({ name: 'attachments' })
 export class Attachment {

--- a/backend/src/entities/Message.ts
+++ b/backend/src/entities/Message.ts
@@ -1,7 +1,7 @@
 // src/entities/Message.ts
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, Index, OneToMany, JoinColumn } from 'typeorm'
-import { Ticket } from './Ticket.js'
-import { Attachment } from './Attachment.js'
+import { Ticket } from './Ticket'
+import { Attachment } from './Attachment'
 
 @Entity({ name: 'messages' })
 export class Message {

--- a/backend/src/entities/Role.ts
+++ b/backend/src/entities/Role.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm'
-import { User } from './User.js'
+import { User } from './User'
 
 @Entity({ name: 'roles' })
 export class Role {

--- a/backend/src/entities/Ticket.ts
+++ b/backend/src/entities/Ticket.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, OneToMany, Index } from 'typeorm'
-import { Message } from './Message.js'
+import { Message } from './Message'
 
 export type TicketStatus = 'open' | 'pending' | 'resolved' | 'closed'
 

--- a/backend/src/entities/User.ts
+++ b/backend/src/entities/User.ts
@@ -1,5 +1,5 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm'
-import { Role } from './Role.js'
+import { Role } from './Role'
 
 @Entity({ name: 'users' })
 export class User {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,19 +1,12 @@
 import { config } from 'dotenv'
 import { fileURLToPath } from 'url'
-import { dirname, resolve } from 'path'
+import { dirname } from 'path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 // Load environment variables
-console.log('Current working directory:', process.cwd())
-const result = config()
-if (result.error) {
-  console.error('Failed to load .env file:', result.error)
-} else {
-  console.log('Environment variables loaded successfully')
-  console.log('DB_USERNAME:', process.env.DB_USERNAME)
-}
+config()
 
 import 'reflect-metadata'
 import express from 'express'
@@ -23,13 +16,15 @@ import cookieParser from 'cookie-parser'
 import rateLimit from 'express-rate-limit'
 import http from 'http'
 import { Server as IOServer } from 'socket.io'
-import { createDataSource } from './database/data-source.js'
-import { registerRoutes } from './routes/index.js'
-import { initWS } from './ws.js'
-import { ensureDirs } from './utils/fs.js' 
+
+import { AppDataSource, createDataSource } from './database/data-source'
+import { registerRoutes } from './routes'
+import { initWS } from './ws'
+import { ensureDirs } from './utils/fs'
 
 // Create DataSource after environment variables are loaded
-const AppDataSource = createDataSource()
+// and expose the shared instance from data-source
+createDataSource()
 
 const app = express()
 

--- a/backend/src/routes/attachments.ts
+++ b/backend/src/routes/attachments.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
-import { requireAuth } from '../middleware/auth.js'
-import { AppDataSource } from '../database/data-source.js'
-import { Attachment } from '../entities/Attachment.js'
+import { requireAuth } from '../middleware/auth'
+import { AppDataSource } from '../database/data-source'
+import { Attachment } from '../entities/Attachment'
 import path from 'path'
 
 const r = Router()

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,8 +1,8 @@
 import { Express } from 'express'
-import auth from './auth.js'
-import tickets from './tickets.js'
-import whatsapp from './whatsapp.js'
-import attachments from './attachments.js'
+import auth from './auth'
+import tickets from './tickets'
+import whatsapp from './whatsapp'
+import attachments from './attachments'
 
 export function registerRoutes (app: Express) {
   app.use('/api/auth', auth)

--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -1,9 +1,9 @@
 import { Router } from 'express'
-import { requireAuth, requireRole } from '../middleware/auth.js'
-import { AppDataSource } from '../database/data-source.js'
-import { Ticket } from '../entities/Ticket.js'
-import { TicketService } from '../services/TicketService.js'
-import { WhatsAppService } from '../services/WhatsAppService.js'
+import { requireAuth, requireRole } from '../middleware/auth'
+import { AppDataSource } from '../database/data-source'
+import { Ticket } from '../entities/Ticket'
+import { TicketService } from '../services/TicketService'
+import { WhatsAppService } from '../services/WhatsAppService'
 
 const r = Router()
 

--- a/backend/src/routes/whatsapp.ts
+++ b/backend/src/routes/whatsapp.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express'
-import { requireAuth, requireRole } from '../middleware/auth.js'
-import { WhatsAppService } from '../services/WhatsAppService.js'
+import { requireAuth, requireRole } from '../middleware/auth'
+import { WhatsAppService } from '../services/WhatsAppService'
 import { promises as fs } from 'fs'
 import path from 'path'
 

--- a/backend/src/seed/seed.ts
+++ b/backend/src/seed/seed.ts
@@ -1,9 +1,9 @@
 import 'reflect-metadata'
 import dotenv from 'dotenv'
 import bcrypt from 'bcryptjs'
-import { AppDataSource } from '../database/data-source.js'
-import { Role } from '../entities/Role.js'
-import { User } from '../entities/User.js'
+import { AppDataSource } from '../database/data-source'
+import { Role } from '../entities/Role'
+import { User } from '../entities/User'
 
 dotenv.config()
 

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -3,7 +3,7 @@ import { ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { useRoute, useRouter } from 'vue-router'
 
-const email = ref('')
+const username = ref('')
 const password = ref('')
 const err = ref('')
 const loading = ref(false)
@@ -15,11 +15,11 @@ async function onSubmit() {
   loading.value = true
   err.value = ''
   try {
-    await auth.login(email.value, password.value)
+    await auth.login(username.value, password.value)
     const to = (route.query.redirect as string) || '/tickets'
     router.replace(to)
   } catch (e: any) {
-    err.value = e?.response?.data?.message || 'Login gagal'
+    err.value = e?.response?.data?.error || 'Login gagal'
   } finally {
     loading.value = false
   }
@@ -35,8 +35,8 @@ async function onSubmit() {
       <h1 class="text-2xl font-semibold mb-4">Masuk ke watiket</h1>
       <div class="space-y-3">
         <div>
-          <label class="text-sm">Email</label>
-          <input v-model="email" type="email" class="w-full border rounded-lg px-3 py-2" />
+          <label class="text-sm">Username</label>
+          <input v-model="username" type="text" class="w-full border rounded-lg px-3 py-2" />
         </div>
         <div>
           <label class="text-sm">Password</label>

--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -16,7 +16,7 @@ const auth = useAuthStore()
 <div class="p-6 space-y-4">
 <h2 class="text-xl font-semibold">Settings</h2>
 <div class="space-y-2">
-<div class="text-sm">User: <b>{{ auth.user?.name }}</b> ({{ auth.user?.role }})</div>
+<div class="text-sm">User: <b>{{ auth.user?.username }}</b> ({{ auth.user?.role }})</div>
 <button class="px-3 py-1.5 rounded-lg border" @click="auth.logout()">Logout</button>
 </div>
 </div>

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -26,8 +26,8 @@ export const useAuthStore = defineStore('auth', {
         this.ready = true
       }
     },
-    async login(email: string, password: string) {
-      const { token, user } = await apiLogin({ email, password })
+    async login(username: string, password: string) {
+      const { token, user } = await apiLogin({ username, password })
       this.token = token
       this.user = user
       localStorage.setItem('token', token)

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,3 +1,3 @@
-export interface LoginPayload { email: string; password: string }
+export interface LoginPayload { username: string; password: string }
 export interface TokenPayload { token: string }
-export interface User { id: number; name: string; role: 'admin' | 'operator' }
+export interface User { id: string; username: string; role: 'admin' | 'operator' }


### PR DESCRIPTION
## Summary
- remove `.js` extensions from local TypeScript imports
- ensure services and routes share the same entity instances for TypeORM
- expose a shared DataSource instance so services use the initialized connection
- initialize shared DataSource before starting server to avoid undefined errors
- consolidate DataSource imports to prevent duplicate identifiers
- streamline environment configuration and group local imports after resolving merge conflicts
- fix frontend login by sending `username` instead of `email`
- align frontend auth types with backend response and show server error messages

## Testing
- `npm test` (fails: Error: no test specified)
- `(backend) npm test` (fails: Missing script: "test")
- `(backend) npm run build`
- `(frontend) npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aebfd82560833298bd0e39259c402d