### PR TITLE
feat: improve ticketing ui and backend

### DIFF
--- a/backend/src/entities/Attachment.ts
+++ b/backend/src/entities/Attachment.ts
@@ -6,9 +6,9 @@ import { Message } from './Message'
 export class Attachment {
   @PrimaryGeneratedColumn('uuid') id!: string
 
-  @ManyToOne(() => Message, m => m.attachments, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Message, m => m.attachments, { onDelete: 'CASCADE', nullable: true })
   @JoinColumn({ name: 'messageId' })   // kolom FK di DB tetap bernama messageId
-  message!: Message
+  message?: Message
 
   @Column({ type: 'varchar', length: 255 }) mime!: string
   @Column({ type: 'varchar', length: 255 }) filename!: string

--- a/backend/src/entities/Message.ts
+++ b/backend/src/entities/Message.ts
@@ -20,6 +20,9 @@ export class Message {
   @Column({ type: 'varchar', length: 255, nullable: true })
   waMessageId?: string
 
+  @Column({ type: 'varchar', length: 20, default: 'sent' })
+  status!: 'sent' | 'read'
+
   @OneToMany(() => Attachment, a => a.message)
   attachments!: Attachment[]
 

--- a/backend/src/routes/attachments.ts
+++ b/backend/src/routes/attachments.ts
@@ -3,10 +3,28 @@ import { requireAuth } from '../middleware/auth'
 import { AppDataSource } from '../database/data-source'
 import { Attachment } from '../entities/Attachment'
 import path from 'path'
+import multer from 'multer'
+import fs from 'fs'
 
 const r = Router()
 
 r.use(requireAuth)
+
+const uploadDir = 'uploads'
+fs.mkdirSync(uploadDir, { recursive: true })
+const upload = multer({ dest: uploadDir })
+
+r.post('/', upload.single('file'), async (req, res) => {
+  if (!req.file) return res.status(400).json({ error: 'No file uploaded' })
+  const repo = AppDataSource.getRepository(Attachment)
+  const att = repo.create({
+    mime: req.file.mimetype,
+    filename: req.file.originalname,
+    path: req.file.path,
+  })
+  await repo.save(att)
+  res.json(att)
+})
 
 r.get('/:id', async (req, res) => {
   const repo = AppDataSource.getRepository(Attachment)

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,11 +3,13 @@ import auth from './auth'
 import tickets from './tickets'
 import whatsapp from './whatsapp'
 import attachments from './attachments'
+import users from './users'
 
 export function registerRoutes (app: Express) {
   app.use('/api/auth', auth)
   app.use('/api/tickets', tickets)
   app.use('/api/whatsapp', whatsapp)
   app.use('/api/attachments', attachments)
+  app.use('/api/users', users)
   app.get('/api/health', (req, res) => res.json({ ok: true }))
 }

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,0 +1,37 @@
+import { Router } from 'express'
+import { requireAuth, requireRole } from '../middleware/auth'
+import { AppDataSource } from '../database/data-source'
+import { User } from '../entities/User'
+import { Role } from '../entities/Role'
+import bcrypt from 'bcryptjs'
+
+const r = Router()
+
+r.use(requireAuth, requireRole('admin'))
+
+r.get('/', async (req, res) => {
+  const repo = AppDataSource.getRepository(User)
+  const users = await repo.find({ relations: { role: true } })
+  res.json(users.map(u => ({ id: u.id, username: u.username, role: u.role.name })))
+})
+
+r.post('/', async (req, res) => {
+  const { username, password, role } = req.body as { username: string; password: string; role?: string }
+  if (!username || !password) return res.status(400).json({ error: 'username and password required' })
+
+  const userRepo = AppDataSource.getRepository(User)
+  const roleRepo = AppDataSource.getRepository(Role)
+
+  const exists = await userRepo.findOne({ where: { username } })
+  if (exists) return res.status(400).json({ error: 'username exists' })
+
+  const roleEnt = await roleRepo.findOne({ where: { name: (role as any) || 'operator' } })
+  if (!roleEnt) return res.status(400).json({ error: 'invalid role' })
+
+  const passwordHash = await bcrypt.hash(password, 10)
+  const user = userRepo.create({ username, passwordHash, role: roleEnt })
+  await userRepo.save(user)
+  res.json({ id: user.id, username: user.username, role: user.role.name })
+})
+
+export default r

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "pinia": "^3.0.3",
     "socket.io-client": "^4.8.1",
     "vue": "^3.5.18",
-    "vue-router": "^4.5.1"
+    "vue-router": "^4.5.1",
+    "qrcode": "^1.5.4"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
@@ -24,6 +25,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "vite": "^7.1.2",
-    "vue-tsc": "^3.0.5"
+    "vue-tsc": "^3.0.5",
+    "@types/qrcode": "^1.5.5"
   }
 }

--- a/frontend/src/api/attachments.ts
+++ b/frontend/src/api/attachments.ts
@@ -1,0 +1,8 @@
+import http from './http'
+
+export async function uploadAttachment(file: File) {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await http.post('attachments', form)
+  return data as { id: string; filename: string; mime: string }
+}

--- a/frontend/src/api/tickets.ts
+++ b/frontend/src/api/tickets.ts
@@ -11,8 +11,8 @@ export async function getTicket(id: number) {
   return data
 }
 
-export async function replyTicket(id: number, body: string) {
-  const { data } = await http.post<Message>(`tickets/${id}/reply`, { body })
+export async function replyTicket(id: number, body: string, attachments: string[] = []) {
+  const { data } = await http.post<Message>(`tickets/${id}/reply`, { body, attachments })
   return data
 }
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,12 @@
+import http from './http'
+import type { User } from '@/types/user'
+
+export async function listUsers() {
+  const { data } = await http.get<User[]>('users')
+  return data
+}
+
+export async function createUser(payload: { username: string; password: string; role: string }) {
+  const { data } = await http.post<User>('users', payload)
+  return data
+}

--- a/frontend/src/api/whatsapp.ts
+++ b/frontend/src/api/whatsapp.ts
@@ -1,0 +1,6 @@
+import http from './http'
+
+export async function startWhatsApp() {
+  const { data } = await http.post<{ ok: boolean; qr: string | null }>('whatsapp/start')
+  return data
+}

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -1,10 +1,26 @@
+<script setup lang="ts">
+import { useAuthStore } from '@/stores/auth'
+const auth = useAuthStore()
+</script>
+
 <template>
-<aside class="w-64 bg-gray-100 h-full border-r border-gray-200 flex flex-col">
-<div class="p-4 text-xl font-semibold">watiket</div>
-<nav class="px-2 space-y-1">
-<RouterLink to="/tickets" class="block px-3 py-2 rounded hover:bg-gray-200">Tickets</RouterLink>
-<RouterLink to="/settings" class="block px-3 py-2 rounded hover:bg-gray-200">Settings</RouterLink>
-</nav>
-<div class="mt-auto p-4 text-sm text-gray-500">v0.1.0</div>
-</aside>
+  <aside class="w-64 bg-gray-100 h-full border-r border-gray-200 flex flex-col dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100">
+    <div class="p-4 text-xl font-semibold">watiket</div>
+    <nav class="px-2 space-y-1">
+      <RouterLink to="/tickets" class="block px-3 py-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800">Tickets</RouterLink>
+      <RouterLink
+        v-if="auth.user?.role === 'admin'"
+        to="/users"
+        class="block px-3 py-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
+        >Users</RouterLink
+      >
+      <RouterLink
+        v-if="auth.user?.role === 'admin'"
+        to="/settings"
+        class="block px-3 py-2 rounded hover:bg-gray-200 dark:hover:bg-gray-800"
+        >Settings</RouterLink
+      >
+    </nav>
+    <div class="mt-auto p-4 text-sm text-gray-500 dark:text-gray-400">v0.1.0</div>
+  </aside>
 </template>

--- a/frontend/src/components/layout/AppTopbar.vue
+++ b/frontend/src/components/layout/AppTopbar.vue
@@ -1,8 +1,23 @@
+<script setup lang="ts">
+import { useThemeStore } from '@/stores/theme'
+const theme = useThemeStore()
+</script>
+
 <template>
-<header class="h-12 border-b border-gray-200 flex items-center justify-between px-4">
-<div class="font-medium">Tickets</div>
-<div class="flex items-center gap-3">
-<slot />
-</div>
-</header>
+  <header
+    class="h-12 border-b border-gray-200 flex items-center justify-between px-4 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100"
+  >
+    <div class="font-medium">Tickets</div>
+    <div class="flex items-center gap-3">
+      <button class="p-2 border rounded" @click="theme.toggle()" aria-label="Toggle theme">
+        <svg v-if="theme.dark" xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zM10 14a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM4.22 4.22a1 1 0 011.42 0l.7.7a1 1 0 01-1.42 1.42l-.7-.7a1 1 0 010-1.42zM14.36 14.36a1 1 0 011.41 0l.7.7a1 1 0 01-1.41 1.41l-.7-.7a1 1 0 010-1.41zM3 10a1 1 0 011-1H4a1 1 0 110 2H4a1 1 0 01-1-1zm12-1a1 1 0 100 2h1a1 1 0 100-2h-1zM5.22 14.78a1 1 0 011.42 0l.7-.7a1 1 0 10-1.42-1.42l-.7.7a1 1 0 000 1.42zM14.36 5.64a1 1 0 011.41 1.41l-.7.7a1 1 0 11-1.41-1.41l.7-.7zM10 6a4 4 0 100 8 4 4 0 000-8z" />
+        </svg>
+        <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M17.293 13.293A8 8 0 016.707 2.707a8 8 0 1010.586 10.586z" />
+        </svg>
+      </button>
+      <slot />
+    </div>
+  </header>
 </template>

--- a/frontend/src/components/tickets/ChatHeader.vue
+++ b/frontend/src/components/tickets/ChatHeader.vue
@@ -7,11 +7,11 @@ const props = defineProps<{ ticket: Ticket | null }>()
 
 
 <template>
-<div class="h-12 border-b border-gray-200 px-4 flex items-center justify-between">
-<div>
-<div class="font-medium">{{ props.ticket?.contactName || props.ticket?.phone || '—' }}</div>
-<div class="text-xs text-gray-500">Status: {{ props.ticket?.status }}</div>
-</div>
-<slot />
+<div class="h-12 border-b border-gray-200 px-4 flex items-center justify-between dark:border-gray-700">
+  <div>
+    <div class="font-medium">{{ props.ticket?.contactName || props.ticket?.phone || '—' }}</div>
+    <div class="text-xs text-gray-500 dark:text-gray-400">Status: {{ props.ticket?.status }}</div>
+  </div>
+  <slot />
 </div>
 </template>

--- a/frontend/src/components/tickets/Composer.vue
+++ b/frontend/src/components/tickets/Composer.vue
@@ -1,18 +1,45 @@
 <script setup lang="ts">
 import { ref } from 'vue'
-const emit = defineEmits<{ (e: 'send', body: string): void }>()
+import { uploadAttachment } from '@/api/attachments'
+const emit = defineEmits<{ (e: 'send', payload: { body: string; attachments: string[] }): void }>()
 const text = ref('')
+const attachments = ref<string[]>([])
+const fileInput = ref<HTMLInputElement | null>(null)
+
+async function onFileChange(e: Event) {
+  const files = (e.target as HTMLInputElement).files
+  if (!files || !files.length) return
+  for (const f of Array.from(files)) {
+    const up = await uploadAttachment(f)
+    attachments.value.push(up.id)
+  }
+  ;(e.target as HTMLInputElement).value = ''
+}
+
 function submit() {
-if (!text.value.trim()) return
-emit('send', text.value.trim())
-text.value = ''
+  if (!text.value.trim() && attachments.value.length === 0) return
+  emit('send', { body: text.value.trim(), attachments: attachments.value })
+  text.value = ''
+  attachments.value = []
 }
 </script>
 
 
 <template>
-<div class="border-t border-gray-200 p-3 flex items-center gap-2">
-<textarea v-model="text" rows="2" placeholder="Tulis pesan…" class="flex-1 resize-none rounded-lg border px-3 py-2 focus:outline-none focus:ring"></textarea>
-<button @click="submit" class="px-4 py-2 rounded-lg bg-emerald-600 text-white">Kirim</button>
+<div class="border-t border-gray-200 p-3 flex items-center gap-2 dark:border-gray-700">
+  <input type="file" class="hidden" ref="fileInput" @change="onFileChange" />
+  <button
+    class="px-3 py-2 border rounded bg-white text-sm dark:bg-gray-800 dark:border-gray-600"
+    @click="(fileInput as any).click()"
+  >
+    📎
+  </button>
+  <textarea
+    v-model="text"
+    rows="2"
+    placeholder="Tulis pesan…"
+    class="flex-1 resize-none rounded-lg border px-3 py-2 focus:outline-none focus:ring dark:bg-gray-800 dark:border-gray-600"
+  ></textarea>
+  <button @click="submit" class="px-4 py-2 rounded-lg bg-emerald-600 text-white">Kirim</button>
 </div>
 </template>

--- a/frontend/src/components/tickets/MessageBubble.vue
+++ b/frontend/src/components/tickets/MessageBubble.vue
@@ -5,13 +5,27 @@ const props = defineProps<{ msg: Message }>()
 
 
 <template>
-<div class="px-4 py-1">
-<div
-class="inline-block max-w-[80%] px-3 py-2 rounded-2xl shadow"
-:class="props.msg.direction === 'out' ? 'bg-emerald-600 text-white rounded-br-sm ml-auto' : 'bg-white rounded-bl-sm'"
->
-<div class="whitespace-pre-wrap">{{ props.msg.body }}</div>
-<div class="text-[10px] opacity-70 text-right mt-1">{{ new Date(props.msg.timestamp).toLocaleString() }}</div>
-</div>
-</div>
+  <div class="px-4 py-1">
+    <div
+      class="inline-block max-w-[80%] px-3 py-2 rounded-2xl shadow"
+      :class="props.msg.direction === 'out'
+        ? 'bg-emerald-600 text-white rounded-br-sm ml-auto'
+        : 'bg-white dark:bg-gray-700 rounded-bl-sm'"
+    >
+      <div class="whitespace-pre-wrap">{{ props.msg.body }}</div>
+      <div v-if="props.msg.attachments?.length" class="mt-2 space-y-1">
+        <div v-for="a in props.msg.attachments" :key="a.id">
+          <img v-if="a.mime.startsWith('image/')" :src="`/api/attachments/${a.id}`" class="max-w-full rounded" />
+          <a v-else :href="`/api/attachments/${a.id}`" target="_blank" class="underline">{{ a.filename }}</a>
+        </div>
+      </div>
+      <div class="text-[10px] opacity-70 text-right mt-1 flex items-center gap-1 justify-end">
+        {{ new Date(props.msg.timestamp).toLocaleString() }}
+        <span v-if="props.msg.direction === 'out'">
+          <span v-if="props.msg.status === 'read'">✓✓</span>
+          <span v-else>✓</span>
+        </span>
+      </div>
+    </div>
+  </div>
 </template>

--- a/frontend/src/components/tickets/TicketList.vue
+++ b/frontend/src/components/tickets/TicketList.vue
@@ -1,17 +1,33 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import type { Ticket } from '@/types/ticket'
 
 const props = defineProps<{ tickets: Ticket[]; activeId: number | null }>()
-const emit = defineEmits<{ (e: 'open', id: number): void }>()
+const emit = defineEmits<{ (e: 'open', id: number): void; (e: 'search', q: string): void }>()
+
+const q = ref('')
+let timer: any
+watch(q, (val) => {
+  clearTimeout(timer)
+  timer = setTimeout(() => emit('search', val), 300)
+})
 </script>
 
 <template>
-  <div class="overflow-y-auto divide-y">
+  <div class="overflow-y-auto divide-y dark:divide-gray-700">
+    <div class="p-2">
+      <input
+        v-model="q"
+        type="text"
+        placeholder="Search..."
+        class="w-full px-2 py-1 text-sm border rounded dark:bg-gray-800 dark:border-gray-700"
+      />
+    </div>
     <button
       v-for="t in props.tickets"
       :key="t.id"
-      class="w-full text-left p-3 hover:bg-gray-50"
-      :class="{ 'bg-gray-100': t.id === props.activeId }"
+      class="w-full text-left p-3 hover:bg-gray-50 dark:hover:bg-gray-800"
+      :class="{ 'bg-gray-100 dark:bg-gray-800': t.id === props.activeId }"
       @click="emit('open', t.id)"
     >
       <div class="flex items-center justify-between">
@@ -22,7 +38,7 @@ const emit = defineEmits<{ (e: 'open', id: number): void }>()
           >{{ t.unreadCount }}</span
         >
       </div>
-      <div class="text-sm text-gray-500 truncate">{{ t.lastMessage }}</div>
+      <div class="text-sm text-gray-500 dark:text-gray-400 truncate">{{ t.lastMessage }}</div>
     </button>
   </div>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,8 +3,11 @@ import { createPinia } from 'pinia'
 import router from './router'
 import App from './App.vue'
 import './assets/index.css'
+import { useThemeStore } from './stores/theme'
 
 const app = createApp(App)
-app.use(createPinia())
+const pinia = createPinia()
+app.use(pinia)
+useThemeStore(pinia).init()
 app.use(router)
 app.mount('#app')

--- a/frontend/src/pages/Settings.vue
+++ b/frontend/src/pages/Settings.vue
@@ -1,26 +1,67 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
 import AppTopbar from '@/components/layout/AppTopbar.vue'
 import { useAuthStore } from '@/stores/auth'
-
+import { useSocket } from '@/composables/useSocket'
+import { startWhatsApp } from '@/api/whatsapp'
+import QRCode from 'qrcode'
 
 const auth = useAuthStore()
+const { waState } = useSocket()
+const qrCanvas = ref<HTMLCanvasElement | null>(null)
+const loading = ref(false)
+
+async function start() {
+  loading.value = true
+  try {
+    await startWhatsApp()
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => waState.value?.qr,
+  async (qr) => {
+    if (qr && qrCanvas.value) {
+      await QRCode.toCanvas(qrCanvas.value, qr, {
+        width: 256,
+        margin: 2,
+        color: { dark: '#000000', light: '#ffffff' }
+      })
+    } else if (qrCanvas.value) {
+      const ctx = qrCanvas.value.getContext('2d')
+      ctx?.clearRect(0, 0, qrCanvas.value.width, qrCanvas.value.height)
+    }
+  }
+)
 </script>
 
 
 <template>
-<div class="h-screen grid grid-cols-[16rem_1fr]">
-<AppSidebar />
-<div class="flex flex-col">
-<AppTopbar />
-<div class="p-6 space-y-4">
-<h2 class="text-xl font-semibold">Settings</h2>
-<div class="space-y-2">
-<div class="text-sm">User: <b>{{ auth.user?.username }}</b> ({{ auth.user?.role }})</div>
-<button class="px-3 py-1.5 rounded-lg border" @click="auth.logout()">Logout</button>
-</div>
-</div>
-</div>
-</div>
+  <div class="h-screen grid grid-cols-[16rem_1fr] dark:bg-gray-800 dark:text-gray-100">
+    <AppSidebar />
+    <section class="flex flex-col">
+      <AppTopbar />
+      <main class="p-6 space-y-6">
+        <h2 class="text-xl font-semibold">Settings</h2>
+        <div class="space-y-2">
+          <div class="text-sm">User: <b>{{ auth.user?.username }}</b> ({{ auth.user?.role }})</div>
+          <button class="px-3 py-1.5 rounded-lg border" @click="auth.logout()">Logout</button>
+        </div>
+        <div class="space-y-2">
+          <h3 class="font-medium">WhatsApp</h3>
+          <div class="text-sm">Status: <b>{{ waState?.connection || 'unknown' }}</b></div>
+          <button class="px-3 py-1.5 rounded-lg border" @click="start" :disabled="loading">
+            Start
+          </button>
+          <div v-if="waState?.qr" class="pt-2">
+            <canvas ref="qrCanvas" class="mx-auto" />
+          </div>
+        </div>
+      </main>
+    </section>
+  </div>
 </template>
 

--- a/frontend/src/pages/Users.vue
+++ b/frontend/src/pages/Users.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import AppSidebar from '@/components/layout/AppSidebar.vue'
+import AppTopbar from '@/components/layout/AppTopbar.vue'
+import { listUsers, createUser } from '@/api/users'
+import type { User } from '@/types/user'
+
+const items = ref<User[]>([])
+const showForm = ref(false)
+const form = ref({ username: '', password: '', role: 'operator' })
+
+onMounted(async () => {
+  items.value = await listUsers()
+})
+
+async function add() {
+  const user = await createUser(form.value)
+  items.value.push(user)
+  form.value = { username: '', password: '', role: 'operator' }
+  showForm.value = false
+}
+</script>
+
+<template>
+  <div class="h-screen grid grid-cols-[16rem_1fr] dark:bg-gray-800 dark:text-gray-100">
+    <AppSidebar />
+    <div class="flex flex-col">
+      <AppTopbar />
+      <div class="p-6">
+        <h2 class="text-xl font-semibold mb-4">Users</h2>
+        <button class="mb-4 px-3 py-1.5 border rounded" @click="showForm = !showForm">
+          {{ showForm ? 'Cancel' : 'Add User' }}
+        </button>
+        <div v-if="showForm" class="mb-4 flex gap-2 items-end flex-wrap">
+          <input v-model="form.username" class="border rounded px-2 py-1 text-sm" placeholder="Username" />
+          <input v-model="form.password" type="password" class="border rounded px-2 py-1 text-sm" placeholder="Password" />
+          <select v-model="form.role" class="border rounded px-2 py-1 text-sm">
+            <option value="operator">operator</option>
+            <option value="admin">admin</option>
+          </select>
+          <button class="px-3 py-1.5 border rounded" @click="add">Save</button>
+        </div>
+        <table class="min-w-[20rem] text-sm">
+          <thead>
+            <tr class="text-left border-b">
+              <th class="py-1 pr-4">Username</th>
+              <th class="py-1">Role</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="u in items" :key="u.id" class="border-b border-gray-200 dark:border-gray-700">
+              <td class="py-1 pr-4">{{ u.username }}</td>
+              <td class="py-1">{{ u.role }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -14,7 +14,13 @@ const routes: RouteRecordRaw[] = [
     path: '/settings',
     name: 'settings',
     component: () => import('@/pages/Settings.vue'),
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, roles: ['admin'] },
+  },
+  {
+    path: '/users',
+    name: 'users',
+    component: () => import('@/pages/Users.vue'),
+    meta: { requiresAuth: true, roles: ['admin'] },
   },
 ]
 
@@ -27,6 +33,10 @@ router.beforeEach((to) => {
   const auth = useAuthStore()
   if (to.meta.requiresAuth && !auth.isAuthenticated) {
     return { name: 'login', query: { redirect: to.fullPath } }
+  }
+  const roles = (to.meta as any).roles as string[] | undefined
+  if (roles && !roles.includes(auth.user?.role || '')) {
+    return { name: 'tickets' }
   }
 })
 

--- a/frontend/src/stores/theme.ts
+++ b/frontend/src/stores/theme.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia'
+
+export const useThemeStore = defineStore('theme', {
+  state: () => ({ dark: false }),
+  actions: {
+    init() {
+      this.dark = localStorage.getItem('dark') === '1'
+      this.apply()
+    },
+    toggle() {
+      this.dark = !this.dark
+      localStorage.setItem('dark', this.dark ? '1' : '0')
+      this.apply()
+    },
+    apply() {
+      const cls = document.documentElement.classList
+      if (this.dark) cls.add('dark')
+      else cls.remove('dark')
+    }
+  }
+})

--- a/frontend/src/stores/ticket.ts
+++ b/frontend/src/stores/ticket.ts
@@ -37,9 +37,9 @@ export const useTicketStore = defineStore('ticket', {
       const t = await getTicket(id)
       this.messages = t.messages || []
     },
-    async send(body: string) {
+    async send(body: string, attachments: string[] = []) {
       if (!this.activeId) return
-      const msg = await replyTicket(this.activeId, body)
+      const msg = await replyTicket(this.activeId, body, attachments)
       this.messages.push(msg)
     },
     async setStatus(status: TicketStatus) {
@@ -50,7 +50,11 @@ export const useTicketStore = defineStore('ticket', {
     },
     upsertIncoming(msg: Message) {
       // dipanggil dari socket event `ticket:updated`
-      if (this.activeId === msg.ticketId) this.messages.push(msg)
+      if (this.activeId === msg.ticketId) {
+        this.messages.push(msg)
+        const lastOut = [...this.messages].reverse().find((m) => m.direction === 'out')
+        if (lastOut) lastOut.status = 'read'
+      }
       const t = this.tickets.find((tt) => tt.id === msg.ticketId)
       if (t) {
         t.lastMessage = msg.body

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -1,4 +1,4 @@
 export interface WaConnectionPayload {
-  state: 'connecting' | 'qr' | 'open' | 'close' | 'error'
-  qr?: string // bila backend kirim qr string
+  connection?: 'connecting' | 'open' | 'close'
+  qr: string | null
 }

--- a/frontend/src/types/ticket.ts
+++ b/frontend/src/types/ticket.ts
@@ -9,6 +9,15 @@ export interface Message {
   to: string
   direction: 'in' | 'out'
   timestamp: string
+  status: 'sent' | 'read'
+  attachments?: Attachment[]
+}
+
+export interface Attachment {
+  id: string
+  mime: string
+  filename: string
+  path: string
 }
 
 

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string
+  username: string
+  role: string
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     './index.html',
     './src/**/*.{vue,ts,tsx}',


### PR DESCRIPTION
## Summary
- switch theme toggle to sun/moon icon
- show WhatsApp connection status and QR code in Settings with start action
- allow admins to add users via new form and backend endpoint
- fix AppTopbar markup to properly close header tag
- correct Settings page markup so all tags close properly
- render WhatsApp QR to a canvas using qrcode package

## Testing
- `npm run build` (backend)
- `npm install` (frontend) *(fails: 403 Forbidden)*
- `npm run build` (frontend) *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b014419d2c8332829dba82538351e2