### PR TITLE
Fix logout flow and WhatsApp reconnection

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -4,10 +4,12 @@ import router from './router'
 import App from './App.vue'
 import './assets/index.css'
 import { useThemeStore } from './stores/theme'
+import { useAuthStore } from './stores/auth'
 
 const app = createApp(App)
 const pinia = createPinia()
 app.use(pinia)
 useThemeStore(pinia).init()
+await useAuthStore(pinia).bootstrap()
 app.use(router)
 app.mount('#app')

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import { defineStore } from 'pinia'
+import router from '@/router'
 import { login as apiLogin, me } from '@/api/auth'
 import type { User } from '@/types/auth'
 
@@ -36,6 +37,9 @@ export const useAuthStore = defineStore('auth', {
       this.token = null
       this.user = null
       localStorage.removeItem('token')
+      if (router.currentRoute.value.name !== 'login') {
+        router.replace({ name: 'login' })
+      }
     },
   },
 })


### PR DESCRIPTION
## Summary
- Redirect to login on logout
- Bootstrap auth store at startup to persist session
- Avoid duplicate WhatsApp connections and reset socket on close

## Testing
- `npm --prefix frontend run build`
- `npm --prefix backend run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a17cfe6c833280d8b827a8726695