### PR TITLE
fix: ensure WhatsApp session subdir exists

### DIFF
--- a/backend/src/services/WhatsAppService.ts
+++ b/backend/src/services/WhatsAppService.ts
@@ -19,11 +19,12 @@ export class WhatsAppService {
   static async start () {
     if (WhatsAppService.sock) return WhatsAppService.sock
     const sessionDir = process.env.WA_SESSION_DIR || './wa-sessions'
+    const primaryDir = path.join(sessionDir, 'primary')
 
     // Ensure directory exists
-    await fs.mkdir(sessionDir, { recursive: true })
+    await fs.mkdir(primaryDir, { recursive: true })
 
-    const { state, saveCreds } = await useMultiFileAuthState(path.join(sessionDir, 'primary'))
+    const { state, saveCreds } = await useMultiFileAuthState(primaryDir)
 
     const sock = makeWASocket({
       printQRInTerminal: true,


### PR DESCRIPTION
## Summary
- create the `primary` subdirectory before initializing Baileys session

## Testing
- `npm --prefix backend run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b24ecce1988332b764dacfabc2ed6a